### PR TITLE
ECM/Crypto management proposal

### DIFF
--- a/usr/lib/enigma2/python/Plugins/Extensions/MyMetrixLite/MainSettingsView.py
+++ b/usr/lib/enigma2/python/Plugins/Extensions/MyMetrixLite/MainSettingsView.py
@@ -21,6 +21,7 @@
 from . import _, initColorsConfig, initWeatherConfig, initOtherConfig, getTunerPositionList, appendSkinFile, \
     SKIN_SOURCE, SKIN_TARGET, SKIN_TARGET_TMP, COLOR_IMAGE_PATH, SKIN_INFOBAR_TARGET, SKIN_INFOBAR_SOURCE, \
     SKIN_SECOND_INFOBAR_SOURCE, SKIN_INFOBAR_TARGET_TMP, SKIN_SECOND_INFOBAR_TARGET, SKIN_SECOND_INFOBAR_TARGET_TMP, \
+    SKIN_SECOND_INFOBARECM_SOURCE, SKIN_SECOND_INFOBARECM_TARGET_TMP, SKIN_SECOND_INFOBARECM_TARGET, SKIN_SECOND_INFOBARECM_TARGET_TMP, \
     SKIN_CHANNEL_SELECTION_SOURCE, SKIN_CHANNEL_SELECTION_TARGET, SKIN_CHANNEL_SELECTION_TARGET_TMP, \
     SKIN_MOVIEPLAYER_SOURCE, SKIN_MOVIEPLAYER_TARGET, SKIN_MOVIEPLAYER_TARGET_TMP, \
 	SKIN_EMC_SOURCE, SKIN_EMC_TARGET, SKIN_EMC_TARGET_TMP
@@ -207,7 +208,10 @@ class MainSettingsView(Screen):
 
             if config.plugins.MetrixWeather.enabled.getValue() is False:
                 infobarSkinSearchAndReplace.append(['<panel name="INFOBARWEATHERWIDGET" />', ''])
-
+            
+            if config.plugins.MyMetrixLiteOther.showInfoBarServerInfo.getValue() is False: 
+                infobarSkinSearchAndReplace.append(['<panel name="INFOBARSERVERINFO" />', '']) 
+				
             if config.plugins.MyMetrixLiteOther.showInfoBarServiceIcons.getValue() is False: 
                 infobarSkinSearchAndReplace.append(['<panel name="INFOBARSERVICEINFO" />', '']) 
 
@@ -252,6 +256,23 @@ class MainSettingsView(Screen):
             move(SKIN_SECOND_INFOBAR_TARGET_TMP, SKIN_SECOND_INFOBAR_TARGET)
 
 
+			#######################
+            # SecondInfoBarEcmType
+            #######################
+
+            secondinfobarEcmTypeSkinSearchAndReplace = []
+
+            secondinfobarEcmTypeSkinSearchAndReplace.append(['<panel name="INFOBAREXTENDEDINFO" />', '<panel name="%s" />' % config.plugins.MyMetrixLiteOther.secondInfoBarEcmInfoType.getValue()])
+
+            skin_lines = appendSkinFile(SKIN_SECOND_INFOBARECM_SOURCE, secondinfobarEcmTypeSkinSearchAndReplace)
+
+            xFile = open(SKIN_SECOND_INFOBARECM_TARGET_TMP, "w")
+            for xx in skin_lines:
+                xFile.writelines(xx)
+            xFile.close()
+
+            move(SKIN_SECOND_INFOBARECM_TARGET_TMP, SKIN_SECOND_INFOBARECM_TARGET)
+			
 
             ################
             # ChannelSelection
@@ -402,7 +423,8 @@ class MainSettingsView(Screen):
             skinSearchAndReplace.append(['skin_00e_ChannelSelection.xml', 'skin_00e_ChannelSelection.MySkin.xml'])
             skinSearchAndReplace.append(['skin_00f_MoviePlayer.xml', 'skin_00f_MoviePlayer.MySkin.xml'])
             skinSearchAndReplace.append(['skin_00g_EMC.xml', 'skin_00g_EMC.MySkin.xml'])
-
+            skinSearchAndReplace.append(['skin_00c_SecondInfoBarECM.xml', 'skin_00c_SecondInfoBarECM.MySkin.xml'])
+			
             skinSearchAndReplace.append(['name="title-foreground" value="#1AFFFFFF"', windowtitletext ])
             skinSearchAndReplace.append(['name="title-background" value="#34FFFFFF"', windowtitletextback ])
             skinSearchAndReplace.append(['name="background-text" value="#34FFFFFF"', backgroundtext ])

--- a/usr/lib/enigma2/python/Plugins/Extensions/MyMetrixLite/OtherSettingsView.py
+++ b/usr/lib/enigma2/python/Plugins/Extensions/MyMetrixLite/OtherSettingsView.py
@@ -137,6 +137,8 @@ class OtherSettingsView(ConfigListScreen, Screen):
         list.append(getConfigListEntry(_("InfoBar/SecondInfobar/MoviePlayer   ------------------------------------------------------------------"), ))
         list.append(getConfigListEntry(_("ChannelName/Number FontSize"), config.plugins.MyMetrixLiteOther.infoBarChannelNameFontSize))
         list.append(getConfigListEntry(_("InfoBar/SecondInfobar   ------------------------------------------------------------------------------"), ))
+        list.append(getConfigListEntry(_("Show Server Name"), config.plugins.MyMetrixLiteOther.showInfoBarServerInfo))
+        list.append(getConfigListEntry(_("Show Second Infobar ECM type"), config.plugins.MyMetrixLiteOther.secondInfoBarEcmInfoType))		
         list.append(getConfigListEntry(_("Show ServiceIcons"), config.plugins.MyMetrixLiteOther.showInfoBarServiceIcons))
         list.append(getConfigListEntry(_("Show Resolution"), config.plugins.MyMetrixLiteOther.showInfoBarResolution))
         list.append(getConfigListEntry(_("Show Clock"), config.plugins.MyMetrixLiteOther.showInfoBarClock))

--- a/usr/lib/enigma2/python/Plugins/Extensions/MyMetrixLite/__init__.py
+++ b/usr/lib/enigma2/python/Plugins/Extensions/MyMetrixLite/__init__.py
@@ -60,6 +60,10 @@ SKIN_SECOND_INFOBAR_SOURCE = "/usr/share/enigma2/MetrixHD/skin_00b_SecondInfoBar
 SKIN_SECOND_INFOBAR_TARGET = "/usr/share/enigma2/MetrixHD/skin_00b_SecondInfoBar.MySkin.xml"
 SKIN_SECOND_INFOBAR_TARGET_TMP = SKIN_SECOND_INFOBAR_TARGET + ".tmp"
 
+SKIN_SECOND_INFOBARECM_SOURCE = "/usr/share/enigma2/MetrixHD/skin_00c_SecondInfoBarECM.xml"
+SKIN_SECOND_INFOBARECM_TARGET = "/usr/share/enigma2/MetrixHD/skin_00c_SecondInfoBarECM.MySkin.xml"
+SKIN_SECOND_INFOBARECM_TARGET_TMP = SKIN_SECOND_INFOBARECM_TARGET + ".tmp"
+
 SKIN_CHANNEL_SELECTION_SOURCE = "/usr/share/enigma2/MetrixHD/skin_00e_ChannelSelection.xml"
 SKIN_CHANNEL_SELECTION_TARGET = "/usr/share/enigma2/MetrixHD/skin_00e_ChannelSelection.MySkin.xml"
 SKIN_CHANNEL_SELECTION_TARGET_TMP = SKIN_CHANNEL_SELECTION_TARGET + ".tmp"
@@ -237,7 +241,12 @@ def initOtherConfig():
         ("INFOBARCHANNELNAME-4", _("50")),
         ("INFOBARCHANNELNAME-5", _("40"))
         ]
-
+		
+    secondInfoBarEcmInfoTypeList = [
+        ("INFOBAREXTENDEDINFO", _("Metrix (Default)")),
+        ("INFOBAREXTENDEDINFOPLI", _("PLi"))
+        ]
+		
     config.plugins.MyMetrixLiteOther = ConfigSubsection()
 
     #OtherSettings
@@ -246,9 +255,11 @@ def initOtherConfig():
     config.plugins.MyMetrixLiteOther.showSYSTemp = ConfigYesNo(default=False)
     config.plugins.MyMetrixLiteOther.showCPUTemp = ConfigYesNo(default=False)
 	#Infobar/Secondinfobar
+    config.plugins.MyMetrixLiteOther.showInfoBarServerInfo = ConfigYesNo(default=True)
     config.plugins.MyMetrixLiteOther.showInfoBarServiceIcons = ConfigYesNo(default=True)
     config.plugins.MyMetrixLiteOther.showChannelNumber = ConfigYesNo(default=True)
     config.plugins.MyMetrixLiteOther.showChannelName = ConfigYesNo(default=True)
+    config.plugins.MyMetrixLiteOther.secondInfoBarEcmInfoType = ConfigSelection(default="INFOBAREXTENDEDINFO", choices = secondInfoBarEcmInfoTypeList)
     config.plugins.MyMetrixLiteOther.infoBarChannelNameFontSize = ConfigSelection(default="INFOBARCHANNELNAME-1", choices = infoBarChannelNameFontSizeList)
     config.plugins.MyMetrixLiteOther.showInfoBarResolution = ConfigYesNo(default=True)
     config.plugins.MyMetrixLiteOther.showInfoBarClock = ConfigYesNo(default=True)

--- a/usr/share/enigma2/MetrixHD/skin_00_templates.xml
+++ b/usr/share/enigma2/MetrixHD/skin_00_templates.xml
@@ -2,7 +2,7 @@
 	<!--/* TEMPLATES -->
 		<!--/* BUTTONS /> -->
 		<screen name="INFOBARKEYSNONVISIBLE">
-			<widget name="key_red" position="105,800" size="240,30" zPosition="1" font="SetrixHD;20" halign="left" backgroundColor="layer-a-background" transparent="1" />
+			<widgete name="key_red" position="105,800" size="240,30" zPosition="1" font="SetrixHD;20" halign="left" backgroundColor="layer-a-background" transparent="1" />
 			<widget name="key_green" position="395,800" size="240,30" zPosition="1" font="SetrixHD;20" halign="left" backgroundColor="layer-a-background" transparent="1" />
 			<widget name="key_yellow" position="685,800" size="240,30" zPosition="1" font="SetrixHD;20" halign="left" backgroundColor="layer-a-background" transparent="1" />
 			<widget name="key_blue" position="975,800" size="240,30" zPosition="1" font="SetrixHD;20" halign="left" backgroundColor="layer-a-background" transparent="1" />
@@ -513,6 +513,24 @@
 			</widget>
 			<!-- CRYPT */ -->
 		</screen>
+		<screen name="INFOBAREXTENDEDINFOPLI">
+			<eLabel backgroundColor="layer-a-background" name="new ePixmap" position="380,33" size="574,87" transparent="0" zPosition="-99"/>
+			<widget source="session.CurrentService" render="Label" backgroundColor="layer-a-background" noWrap="1" position="386,38" size="558,60" font="Regular;16" halign="left" foregroundColor="layer-a-accent1" transparent="1" zPosition="10" >
+				<convert type="PliExtraInfo">All</convert>
+			</widget>
+			<!-- /* AGC -->
+			<eLabel text="AGC:" position="386,98" size="35,15" font="Regular; 15" halign="left" valign="center" backgroundColor="layer-a-background" foregroundColor="layer-a-accent1" transparent="1" />
+			<widget source="session.FrontendStatus" render="Label" position="426,98" size="40,15" font="Regular; 15" backgroundColor="layer-a-background" foregroundColor="layer-a-accent1" transparent="1" halign="left">
+				<convert type="FrontendInfo">AGC</convert>
+			</widget>
+			<!-- AGC */-->
+			<!-- /* BER -->
+			<eLabel text="BER:" position="485,98" size="35,15" font="Regular; 15" halign="left" valign="center" backgroundColor="layer-a-background" foregroundColor="layer-a-accent1" transparent="1" />
+			<widget source="session.FrontendStatus" render="Label" position="520,98" size="40,15" font="Regular; 15" backgroundColor="layer-a-background" foregroundColor="layer-a-accent1" transparent="1" halign="left">
+				<convert type="FrontendInfo">BER</convert>
+			</widget>
+			<!-- BER */-->
+		</screen>
 		<screen name="INFOBARSNR">
 			<!-- /* SNR -->
 			<eLabel text="SNR:" position="424,666" size="50,26" font="RegularLight; 24" halign="left" valign="center" backgroundColor="layer-a-background" foregroundColor="layer-a-accent1" transparent="1" />
@@ -783,6 +801,13 @@
 				<convert type="ConditionalShowHide" />
 			</widget>
 			<!-- TunerInfo */-->
+		</screen>
+		<screen name="INFOBARSERVERINFO">
+			<!-- /* SeverInfo -->
+			<widget source="session.CurrentService" render="Label"  backgroundColor="layer-a-background" position="286,697" size="300,20" font="Regular;16" halign="left" foregroundColor="layer-a-accent1" transparent="1" zPosition="10">
+				<convert type="CryptoInfo">VerboseInfo</convert>
+			</widget>
+			<!-- ServerInfo */-->
 		</screen>
 		<screen name="INFOBARSERVICEINFO">
 			<!--/* SERVICE INFO -->

--- a/usr/share/enigma2/MetrixHD/skin_00a_InfoBar.xml
+++ b/usr/share/enigma2/MetrixHD/skin_00a_InfoBar.xml
@@ -5,6 +5,7 @@
 		<panel name="CLOCKWIDGET" />
 		<panel name="INFOBARWEATHERWIDGET" />
 		<panel name="CHANNELNAME" />
+		<panel name="INFOBARSERVERINFO" />
 		<panel name="INFOBARSERVICEINFO" />
 		<panel name="INFOBARRECORDSTATE" />
 		<panel name="INFOBARRESOLUTION" />

--- a/usr/share/enigma2/MetrixHD/skin_00b_SecondInfoBar.xml
+++ b/usr/share/enigma2/MetrixHD/skin_00b_SecondInfoBar.xml
@@ -4,6 +4,7 @@
 		<panel name="INFOBARSTYLEMODERN" />
 		<panel name="CLOCKWIDGET" />
 		<panel name="INFOBARWEATHERWIDGET" />
+		<panel name="INFOBARSERVERINFO" />
 		<panel name="INFOBARSERVICEINFO" />
 		<panel name="INFOBARRECORDSTATE" />
 		<panel name="INFOBARRESOLUTION" />

--- a/usr/share/enigma2/MetrixHD/skin_00d_InfoBarLite.xml
+++ b/usr/share/enigma2/MetrixHD/skin_00d_InfoBarLite.xml
@@ -3,6 +3,7 @@
 		<panel name="INFOBARKEYSNONVISIBLE" />
 		<panel name="INFOBARSTYLEMODERN" />
 		<panel name="INFOBARCHANNELNAME" />
+		<panel name="INFOBARSERVERINFO" />
 		<panel name="INFOBARSERVICEINFO" />
 		<panel name="INFOBARRECORDSTATE" />
 		<panel name="INFOBARTUNERINFO" />


### PR DESCRIPTION
Hello

i have modified the plugin and some xml files in order to:
- add possibility to select kind of ECM info in second infobar (default Metrix converter or PLi one, using PliExtraInfo converter -- very details information)
- add possibility to show server name in infobar (using CryptoInfo converter).
  This will be shown in followinh shape:
  server_name@hop(ecm time)   ---> very intuitive
  if lib/python/Tools/GetEcmInfo.py is synchornised with http://sourceforge.net/p/openpli/enigma2/ci/master/tree/lib/python/Tools/GetEcmInfo.py

with current GetEcmInfo.py version, the shape is as following:
Server: server_name

Thank you for your feedback.
