### PR TITLE
MyMetrixLite.po: fixed typo

### DIFF
--- a/usr/lib/enigma2/python/Plugins/Extensions/MyMetrixLite/locale/de/LC_MESSAGES/MyMetrixLite.po
+++ b/usr/lib/enigma2/python/Plugins/Extensions/MyMetrixLite/locale/de/LC_MESSAGES/MyMetrixLite.po
@@ -830,7 +830,7 @@ msgstr "Layer A und B gleiche Höhe, Uhr in Layer A"
 
 #: __init__.py:299
 msgid "Layer A and B same height, Clock in Layer B"
-msgstr "Layer A and B gleiche Höhe, Uhr in Layer B"
+msgstr "Layer A und B gleiche Höhe, Uhr in Layer B"
 
 #
 msgid "Chose Extended-Info Style"


### PR DESCRIPTION
replaced a "and" with "und"
