### PR TITLE
openatv.xml - fix skin error in 'aboutoe' screen

### DIFF
--- a/usr/share/enigma2/MetrixHD/skin_01_openatv.xml
+++ b/usr/share/enigma2/MetrixHD/skin_01_openatv.xml
@@ -11,7 +11,7 @@
 		<eLabel text="https://github.com/openatv" position="825,470" size="380,30" font="screen_info;20" backgroundColor="layer-b-background" foregroundColor="layer-b-foreground" halign="center" transparent="0" zPosition="1" />
 		<eLabel text="https://github.com/oe-alliance" position="825,520" size="380,30" font="screen_info;20" backgroundColor="layer-b-background" foregroundColor="layer-b-foreground" halign="center" transparent="0" zPosition="1" />
 		<ePixmap position="890,175" size="256,256" zPosition="10" pixmap="MetrixHD/icons/infopanel.png" transparent="1" alphatest="blend" />
-		<panel name="rg__-keys_template1" />
+		<panel name="_g__-keys_template1" />
 		<panel name="rg__-buttons_template1" />
 		<eLabel text="Close" position="70,638" size="170,30" noWrap="1" zPosition="1" valign="center" font="global_button; 20" halign="left" backgroundColor="layer-a-background" foregroundColor="layer-a-button-foreground" transparent="1" />
 		<panel name="template1_2layer" />


### PR DESCRIPTION
[SKIN] processing screen AboutOE:
[SKIN] SKIN ERROR in screen 'AboutOE' widget 'widget':
{MetrixHD/skin.MySkin.xml}: component with name 'key_red' was not found
in skin of screen 'AboutOE'!. Please contact the skin's author!