### PR TITLE
fix for df44b15c1e9f45249daf14d7b856fada24601e2e: remove quick subtitles menu override

### DIFF
--- a/usr/share/enigma2/MetrixHD/skin_00o_openatv.xml
+++ b/usr/share/enigma2/MetrixHD/skin_00o_openatv.xml
@@ -3565,12 +3565,6 @@ self.instance.move(ePoint(int(deskwidth - newwidth)/2,int(deskheight - newheight
 	</screen>
 	<!-- Subtitle -->
 	<screen name="SubtitleDisplay" position="0,0" size="1280,720" zPosition="-1" flags="wfNoBorder" backgroundColor="transparent" />
-	<screen name="QuickSubtitlesConfigMenu" position="265,150" size="750,350" title="Subtitle settings" backgroundColor="transparent" flags="wfNoBorder">
-		<eLabel position="0,0" size="750,350" zPosition="-11" backgroundColor="layer-b-background" />
-		<eLabel position="1,1" size="748,348" zPosition="-10" backgroundColor="layer-a-background" />
-		<widget name="config" position="5,5" size="740,300" itemHeight="30" font="screen_text; 20" scrollbarMode="showOnDemand" enableWrapAround="1" backgroundColor="layer-a-background" foregroundColor="layer-a-foreground" backgroundColorSelected="layer-a-selection-background" foregroundColorSelected="layer-a-selection-foreground" transparent="1" />
-		<widget name="videofps" position="5,300" size="740,50" backgroundColor="layer-a-background" transparent="1" zPosition="1" font="screen_text;20" valign="center" halign="center" foregroundColor="layer-a-accent1"/>
-	</screen>
 	<!-- Service Scan Screens -->
 	<screen name="NimSelection" position="0,0" size="1280,720" title="Choose Tuner" flags="wfNoBorder" backgroundColor="transparent">
 		<eLabel text="Choose Tuner" position="58,36" foregroundColor="layer-a-title-foreground" size="525,50" valign="bottom" font="global_title;34" backgroundColor="layer-a-background" transparent="1" />


### PR DESCRIPTION
Before df44b15c1e9f45249daf14d7b856fada24601e2e ([this line](https://github.com/openatv/MetrixHD/commit/df44b15c1e9f45249daf14d7b856fada24601e2e#diff-439803ad023de70ea678265bb9e37bb5R3130)) the quick subtitles menu were not defined in MetrixHD and the skinning from skin_default.xml were used. That standard skinning were better for this dialog because the quick menu were displayed at the corner of the screen (instead of the center) taking less screen estate which is very important for the purpose of this dialog. The quick menu is very often used to adjust subtitles syncing (via setting “Delay”) and for this it is usually necessary to keep the dialog (menu) displayed for longer time. When the dialog appears at the center of the screen it is not very useful.

**This fix activates the old small dialog.**

**Small dialog** (which will be active again):
![quicksubtitlesconfigmenu-fixed](https://cloud.githubusercontent.com/assets/3368402/15890711/35822e70-2d71-11e6-9fc5-12d7d95079ab.png)

**Dialog introduced in df44b15c1e9f45249daf14d7b856fada24601e2e** (will be replaced):
![quicksubtitlesconfigmenu-large](https://cloud.githubusercontent.com/assets/3368402/15890729/485afb30-2d71-11e6-971b-24e235f7167f.png)

The small dialog is also partially transparent which is another advantage.