### PR TITLE
Changes to top mainmenu bar.

### DIFF
--- a/usr/share/enigma2/MetrixHD/skin_00_templates.xml
+++ b/usr/share/enigma2/MetrixHD/skin_00_templates.xml
@@ -1555,15 +1555,15 @@
 			<!--ClockWidget */-->
 		</screen>
 		<screen name="MenuButtons_template">
-			<eLabel backgroundColor="menubackground" position="0,0" size="1280,20" transparent="0" zPosition="-1"/>
+			<eLabel backgroundColor="menubackground" position="0,0" size="1280,22" transparent="0" zPosition="-1"/>
 			<!--ePixmap pixmap="MetrixHD/buttons/key_red.png" position="265,0" size="30,20" alphatest="blend" /-->
 			<ePixmap pixmap="MetrixHD/buttons/key_green.png" position="448,0" size="30,20" alphatest="blend" />
 			<ePixmap pixmap="MetrixHD/buttons/key_yellow.png" position="631,0" size="30,20" alphatest="blend" />
 			<ePixmap pixmap="MetrixHD/buttons/key_blue.png" position="814,0" size="30,20" alphatest="blend" />
-			<!--widget name="key" position="300,0" size="170,18" zPosition="1" valign="center" font="global_button;18" halign="left" noWrap="1" foregroundColor="layer-a-button-foreground" backgroundColor="menubackground" transparent="1" /-->
-			<widget name="green" position="483,0" size="170,18" zPosition="1" valign="center" font="global_button;18" halign="left" noWrap="1" foregroundColor="layer-a-button-foreground" backgroundColor="menubackground" transparent="1" />
-			<widget name="yellow" position="666,0" size="170,18" zPosition="1" valign="center" font="global_button;18" halign="left" noWrap="1" foregroundColor="layer-a-button-foreground" backgroundColor="menubackground" transparent="1" />
-			<widget name="blue" position="849,0" size="170,18" zPosition="1" valign="center" font="global_button;18" halign="left" noWrap="1" foregroundColor="layer-a-button-foreground" backgroundColor="menubackground" transparent="1" />
+			<!--widget name="key" position="300,0" size="170,22" zPosition="1" valign="center" font="global_button;18" halign="left" noWrap="1" foregroundColor="layer-a-button-foreground" backgroundColor="menubackground" transparent="1" /-->
+			<widget name="green" position="483,0" size="170,22" zPosition="1" valign="center" font="global_button;18" halign="left" noWrap="1" foregroundColor="layer-a-button-foreground" backgroundColor="menubackground" transparent="1" />
+			<widget name="yellow" position="666,0" size="170,22" zPosition="1" valign="center" font="global_button;18" halign="left" noWrap="1" foregroundColor="layer-a-button-foreground" backgroundColor="menubackground" transparent="1" />
+			<widget name="blue" position="849,0" size="170,22" zPosition="1" valign="center" font="global_button;18" halign="left" noWrap="1" foregroundColor="layer-a-button-foreground" backgroundColor="menubackground" transparent="1" />
 		</screen>
 		<screen name="MENU_template-1">
 			<eLabel position="645,51" zPosition="-11" size="482,558" backgroundColor="menubackground" transparent="0" />


### PR DESCRIPTION
Currently characters like "j" "g" etc. are missing the lower part because there is not enough space.
I increased the seize of the field a little so those characters are shown correctly.

Before/afther. :

![1_0_1_30_5_85_c00000_0_0_0](https://user-images.githubusercontent.com/7928052/27432211-8a836110-574f-11e7-9b22-504b0a955573.jpg)
