### PR TITLE
[WlanScan-Screen] fix scrolling in FHD

### DIFF
--- a/usr/share/enigma2/MetrixHD/skin_00o_openatv.xml
+++ b/usr/share/enigma2/MetrixHD/skin_00o_openatv.xml
@@ -256,7 +256,7 @@
 		<eLabel text="Scan wireless networks" position="58,36" foregroundColor="layer-a-title-foreground" size="525,50" valign="bottom" font="global_title;34" backgroundColor="layer-a-background" transparent="1" />
 		<widget source="info" render="Label" position="70,100" size="700,32" font="SetrixHD;24" backgroundColor="layer-a-background" transparent="1" />
 		<eLabel position="70,155" size="700,2" backgroundColor="layer-a-accent1" />
-		<widget source="list" render="Listbox" position="70,165" size="700,450" scrollbarMode="showOnDemand" transparent="1">
+		<widget source="list" render="Listbox" position="70,165" size="700,455" scrollbarMode="showOnDemand" transparent="1">
 			<convert type="TemplatedMultiContent">
 				{"template": [
 						MultiContentEntryText(pos = (10, 2), size = (650, 40), font=0, flags = RT_HALIGN_LEFT, text = 0), # index 0 is the essid


### PR DESCRIPTION
Wenn man 6 oder mehr WLAN-Netze sieht, dann wurde schon beim Scrollen auf Nr.6 eine Seite weiter geblättert
Jetzt bleibt der Scrollbalken noch auf Nr.6 auf der ersten Seite stehen.
Habe das mit HD und FHD mit Standard-Einstellungen getestet