### PR TITLE
Fix for recent EMC screenname change

### DIFF
--- a/usr/share/enigma2/MetrixHD/skin_00g_EMC.xml
+++ b/usr/share/enigma2/MetrixHD/skin_00g_EMC.xml
@@ -455,6 +455,10 @@
 		<panel name="rgyb-keys_template1" />
 		<panel name="ime-buttons_template1" />
 	</screen>
+	<!-- EMC : Enhanced Movie Center -New mainscreen name as of EMC git20171228- -->
+	<screen name="EMCSelectionOwn" position="0,0" size="1280,720" title="Enhanced Movie Center" flags="wfNoBorder" backgroundColor="transparent">
+		<panel name="EMCSelection" />
+	</screen>
 	<!-- EMCMediacenter -->
 	<screen name="EMCMediaCenter" position="0,0" size="1280,720" title="InfoBar" flags="wfNoBorder" backgroundColor="transparent">
 		<panel name="EMCMediaCenter_2" />


### PR DESCRIPTION
Seems EMC has recently changed the screenname from `EMCSelection` to `EMCSelectionOwn`.
Here a simple fix that redirects to the original/previous screenname. 
Tested locally and working.