### PR TITLE
Revert Fix for recent EMC screenname change

### DIFF
--- a/usr/share/enigma2/MetrixHD/skin_00g_EMC.xml
+++ b/usr/share/enigma2/MetrixHD/skin_00g_EMC.xml
@@ -455,10 +455,6 @@
 		<panel name="rgyb-keys_template1" />
 		<panel name="ime-buttons_template1" />
 	</screen>
-	<!-- EMC : Enhanced Movie Center -New mainscreen name as of EMC git20171228- -->
-	<screen name="EMCSelectionOwn" position="0,0" size="1280,720" title="Enhanced Movie Center" flags="wfNoBorder" backgroundColor="transparent">
-		<panel name="EMCSelection" />
-	</screen>
 	<!-- EMCMediacenter -->
 	<screen name="EMCMediaCenter" position="0,0" size="1280,720" title="InfoBar" flags="wfNoBorder" backgroundColor="transparent">
 		<panel name="EMCMediaCenter_2" />


### PR DESCRIPTION
EMC has added a menu option to select what skin to use.
(The E2 Skin or the buildin EMC skin.)
The default option is set to the EMC-buildin skin, and therefor uses a new screenname.
Users are able to switch in the EMC settings, so there is no need for the earlier PR anymore.