### PR TITLE
Update MetrixHDXPicon.py - InfoBar big size picon not visible on service 4097

### DIFF
--- a/usr/lib/enigma2/python/Components/Renderer/MetrixHDXPicon.py
+++ b/usr/lib/enigma2/python/Components/Renderer/MetrixHDXPicon.py
@@ -83,10 +83,11 @@ class MetrixHDXPicon(Renderer):
 				if pngname == "":
 					pngname = self.findPicon(sname)
 					if pngname == "":
-						if len(fields) > 0 and fields[0] != '1':                   #fallback to 1 for IPTV streams
+						fields = sname.split('_', 3)
+						if len(fields) > 0 and fields[0] != '1':                    #fallback to 1 for IPTV streams
 							fields[0] = '1'
 							pngname = self.findPicon('_'.join(fields))
-						if pngname == "" and len(fields) > 2 and fields[2] != '2': #fallback to 1 for find picons with not defined stream quality
+						if pngname == "" and len(fields) > 2 and fields[2] != '2':  #fallback to 1 for find picons with not defined stream quality
 							fields[2] = '1'
 							pngname = self.findPicon('_'.join(fields))
 					if not pngname: # picon by channel name


### PR DESCRIPTION
Of course, this can be solved, but it will be very inefficient in my opinion (unnecessary rows in the Python code). It would be best to modify the _FindPicon.py_ and _Picon.py_ code to ignore the first three values ​​in the Service Reference Code when searching picon. However, this could also mean Enigma compatibility issues (I'm not so much involved in Enigma-programming).

**MetrixHDXPicon.py:**

https://www.opena.tv/english-section/37727-iptv-picons-using-gstreamer-service-4097-instead-using-dvb-service-1-a-2.html

The problem is that if a picon is not found. Then the algorithm resets the third and first digit in the service reference code at the same time to digit 1 and tries again to find the picon. That's a mistake. First, the algorithm should change the first figure and look for the picon, then the second figure and look again for the picon.

I need the first digit for IPTV purpose always sets to 1 and I need too the third digit to remain unchanged and unfortunately the code changes it from the original 2+ to 1 (if there is a number 2 it mean a radio, so the value 2 is ignored, of course).

Best, however, if the algorithm tried to look specifically at all possible combinations:

4097_0_1
4097_0_original
1_0_1
1_0_original

Picons exists separately for SD, HD and UHD channels (with lowercase text of "SD" or "HD" or "4K" in the picons). Some lamedb databases do not include a number 16 for SD, or 19 for HD, or 1F for UHD, but uses only 1 (when stream quality is not defined).

Therefore, it would be best to edit the two mentioned files that perform the first picon search and also fill in a temporary cache (global variable type dictionary, called nameCache).