### PR TITLE
invisible picons in InfoBar for IPTV stream

### DIFF
--- a/usr/lib/enigma2/python/Components/Renderer/MetrixHDXPicon.py
+++ b/usr/lib/enigma2/python/Components/Renderer/MetrixHDXPicon.py
@@ -84,11 +84,12 @@ class MetrixHDXPicon(Renderer):
 					pngname = self.findPicon(sname)
 					if pngname == "":
 						fields = sname.split('_', 3)
-						if len(fields) > 2 and fields[2] != '2': #fallback to 1 for tv services with nonstandard servicetypes
-							fields[2] = '1'
-						if len(fields) > 0 and fields[0] != '1': #fallback to 1 for IPTV streams
+						if len(fields) > 0 and fields[0] != '1':                     #fallback to 1 for IPTV streams
 							fields[0] = '1'
-						pngname = self.findPicon('_'.join(fields))
+							pngname = self.findPicon('_'.join(fields))
+						if pngname == "" and len(fields) > 2 and fields[2] != '2':   #fallback to 1 for find picons with not defined stream quality
+							fields[2] = '1'
+							pngname = self.findPicon('_'.join(fields))
 					if not pngname: # picon by channel name
 						name = ServiceReference(self.source.text).getServiceName()
 						name = unicodedata.normalize('NFKD', unicode(name, 'utf_8', errors='ignore')).encode('ASCII', 'ignore')


### PR DESCRIPTION
It would be best to modify the FindPicon.pyo and Picon.pyo code to ignore the first three values ​​in the Service Reference Code when searching. However, this could also mean Enigma compatibility issues (I'm not so much involved in Enigma-programming, so I can not say).

MetrixHDXPicon.py:

The problem is that if a picon is not found, then the algorithm resets the third and first digit in the service reference code at the same time to digit 1 and tries again to find the picon. That's a mistake. First, the algorithm should change the first figure and look for the picon, then the second figure and look again for the picon.

In my particular case, I need the first digit to be even for IPTV every 1 that's ok. But I need the third digit to remain unchanged and unfortunately the code changes it from the original "> 2" to 1 (if there is a number 2 it is a radio, so there is of course the value 2 is ignored).

Best, however, if the algorithm tried to look specifically at all possible combinations:
4097_0_1
4097_0_original
1_0_1
1_0_original
---- original - means the quality of the stream, for example: 16 for SD, 19 for HD and 1F for UHD
Picons exist especially for HD, SD and UHD channels (with lowercase HD and SD and 4K in picon). In other words, some lamedb databases do not include a 16-bit SD or 19 for HD or 1F for UHD, but only a number of 1, but there is no third number in the status of 1, but only as: 16, 19, 1F.

Therefore, it would be best to edit the two mentioned files that perform the first picon search and also fill in a temporary cache (global variable type dictionary, called nameCache).