### PR TITLE
Update sk.po

### DIFF
--- a/locale/sk.po
+++ b/locale/sk.po
@@ -904,16 +904,16 @@ msgid "Info: Setting applies not for EMC."
 msgstr "Info: Nastavenie sa nevzťahuje na EMC."
 
 msgid "InfoBar"
-msgstr "InfoPanel"
+msgstr "InfoBar"
 
 msgid "Infobar, Moviebar"
-msgstr "InfoPanel a video InfoPanel"
+msgstr "InfoBar a VideoBar"
 
 msgid "InfoBar/SecondInfobar"
-msgstr "InfoPanel/druhý InfoPanel"
+msgstr "InfoBar / druhý InfoBar"
 
 msgid "InfoBar/SecondInfobar/Moviebar"
-msgstr "InfoPanel/druhý InfoPanel/video InfoPanel"
+msgstr "InfoBar / druhý InfoBar / VideoBar"
 
 msgid "Information"
 msgstr "Informácie"


### PR DESCRIPTION
"InfoBar" and "InfoPanel" are two totally different views in Enigma2 ! The concept of "InfoPanel" is already being used in Enigma2 systems for another purpose ! It is therefore better if the original term is used - i.e. "InfoBar". Otherwise, the terms will be confusing. I returned this term to the original English "InfoBar", instead of the Slovak "InfoPanel".