### PR TITLE
Allow genre list display in graphical EPGs

### DIFF
--- a/usr/share/enigma2/MetrixHD/skin_00o_openatv.xml
+++ b/usr/share/enigma2/MetrixHD/skin_00o_openatv.xml
@@ -3315,8 +3315,11 @@ self.instance.move(ePoint(int(deskwidth - newwidth)/2,int(deskheight - newheight
 		<ePixmap position="534,46" size="36,36" zPosition="10" pixmap="MetrixHD/left.png" alphatest="on" />
 		<ePixmap position="940,46" size="36,36" zPosition="10" pixmap="MetrixHD/right.png" alphatest="on" />
 		<widget source="Title" render="Label" position="550,36" foregroundColor="epg-timeline-foreground" size="410,50" noWrap="1" halign="center" valign="bottom" font="global_title;34" backgroundColor="epg-background" transparent="1" />
-		<widget source="Event" render="Label" position="60,82" size="830,40" font="epg_event;24" backgroundColor="epg-background" foregroundColor="epg-event-foreground" transparent="0">
+		<widget source="Event" render="Label" position="60,82" size="525,40" font="epg_event;24" backgroundColor="epg-background" foregroundColor="epg-event-foreground" transparent="0">
 			<convert type="EventName">Name</convert>
+		</widget>
+		<widget source="Event" render="Label" position="590,87" size="300,25" halign="right" font="epg_info;19" backgroundColor="epg-background" foregroundColor="epg-event-foreground" transparent="0">
+			<convert type="EventName">GenreList</convert>
 		</widget>
 		<widget source="session.VideoPicture" render="Pig" position="895,95" size="326,183" zPosition="3" backgroundColor="unff000000" />
 		<widget source="session.CurrentService" render="Label" position="895,92" size="326,30" zPosition="4" font="epg_text; 18"  halign="center" valign="top" noWrap="1" backgroundColor="transparent" foregroundColor="epg-event-foreground" borderColor="black" borderWidth="1" transparent="1">
@@ -3405,11 +3408,11 @@ self.instance.move(ePoint(int(deskwidth - newwidth)/2,int(deskheight - newheight
 		<ePixmap position="534,46" size="36,36" zPosition="10" pixmap="MetrixHD/left.png" alphatest="on" />
 		<ePixmap position="940,46" size="36,36" zPosition="10" pixmap="MetrixHD/right.png" alphatest="on" />
 		<widget source="Title" render="Label" position="550,36" foregroundColor="epg-timeline-foreground" size="410,50" noWrap="1" halign="center" valign="bottom" font="global_title;34" backgroundColor="epg-background" transparent="1" />
-		<widget source="Event" render="Label" position="60,82" size="950,40" font="epg_event;24" backgroundColor="epg-background" foregroundColor="epg-event-foreground" transparent="0">
+		<widget source="Event" render="Label" position="60,82" size="850,40" font="epg_event;24" backgroundColor="epg-background" foregroundColor="epg-event-foreground" transparent="0">
 			<convert type="EventName">Name</convert>
 		</widget>
-		<widget source="Event" render="Label" position="1020,87" size="200,40" halign="right" font="epg_info;19" backgroundColor="epg-background" foregroundColor="epg-event-foreground" transparent="0">
-			<convert type="EventName">Genre</convert>
+		<widget source="Event" render="Label" position="920,87" size="300,25" halign="right" font="epg_info;19" backgroundColor="epg-background" foregroundColor="epg-event-foreground" transparent="0">
+			<convert type="EventName">GenreList</convert>
 		</widget>
 		<eLabel position="60,135" zPosition="0" size="1160,142" backgroundColor="epg-eventdescription-background" transparent="0" />
 		<panel name="RTSB_gEPG1_description"/>


### PR DESCRIPTION
Switch GraphicalEPG to use GenreList instead of Genre to display
multiple genres in IceTV data. Adjust event name and genre widths
to allow more space for genre information.

Add GenreList to GraphicalEPGPIG.

Relative widths of the event name and genre lists may need some
adjustment.