### PR TITLE
[Weather] Fix special case service info extended and make week day font configureable

### DIFF
--- a/locale/MyMetrixLite.pot
+++ b/locale/MyMetrixLite.pot
@@ -521,6 +521,9 @@ msgstr ""
 msgid "Clock text"
 msgstr ""
 
+msgid "Weather week text"
+msgstr ""
+
 msgid "Large text"
 msgstr ""
 

--- a/locale/de.po
+++ b/locale/de.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: openATV / MyMetrixLite\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-02-04 01:00+0300\n"
-"PO-Revision-Date: 2021-05-20 14:09+0200\n"
+"PO-Revision-Date: 2021-05-24 07:48+0200\n"
 "Last-Translator: 4l3x2k <4l3x2k@users.noreply.github.com>\n"
 "Language-Team: mike99\n"
 "Language: de\n"
@@ -473,6 +473,9 @@ msgstr "Uhr in Layer B"
 
 msgid "Clock text"
 msgstr "Uhr"
+
+msgid "Weather week text"
+msgstr "Wetter Wochentag"
 
 msgid "Clock, Weather and Buttons"
 msgstr "Uhr, Wetter und Schaltflächen"

--- a/usr/lib/enigma2/python/Plugins/Extensions/MyMetrixLite/ActivateSkinSettings.py
+++ b/usr/lib/enigma2/python/Plugins/Extensions/MyMetrixLite/ActivateSkinSettings.py
@@ -261,7 +261,7 @@ class ActivateSkinSettings:
 						else: # Weather enabled with normal symbols and extended info disabled and weekday enabled
 							infobarSkinSearchAndReplace.append(['<panel name="INFOBARWEATHERWIDGET+1" />', '<panel name="INFOBARWEATHERWIDGET+%s_weekday" />' % config.plugins.MetrixWeather.forecast.value])
 					else: # Weather enabled with normal symbols and extended info enabled
-						if config.plugins.MyMetrixLiteOther.ExtendedinfoStyle.getValue() == "2": # Weather enabled with normal symbols and extended info enabled between clock and weather enclosed
+						if config.plugins.MyMetrixLiteOther.ExtendedinfoStyle.getValue() == "2" or config.plugins.MyMetrixLiteOther.ExtendedinfoStyle.getValue() == "3": # Weather enabled with normal symbols and extended info enabled between clock and weather enclosed or centered
 							if config.plugins.MetrixWeather.weekday.getValue() is False: # Weather enabled with normal symbols and extended info enabled between clock and weather enclosed and weekday disabled
 								if config.plugins.MetrixWeather.forecast.getValue() > 0: # Weather enabled with normal symbols and extended info enabled between clock and weather enclosed and weekday disabled and forecast greater than one days
 									infobarSkinSearchAndReplace.append(['<panel name="INFOBARWEATHERWIDGET+1" />', '<panel name="INFOBARWEATHERWIDGET+1" />'])
@@ -277,22 +277,22 @@ class ActivateSkinSettings:
 								infobarSkinSearchAndReplace.append(['<panel name="INFOBARWEATHERWIDGET+1" />', '<panel name="INFOBARWEATHERWIDGET+%s" />' % config.plugins.MetrixWeather.forecast.value])
 							else: # Weather enabled with normal symbols and extended info disabled and weekday enabled
 								infobarSkinSearchAndReplace.append(['<panel name="INFOBARWEATHERWIDGET+1" />', '<panel name="INFOBARWEATHERWIDGET+%s_weekday" />' % config.plugins.MetrixWeather.forecast.value])
-				else:
+				else: # Weather enabled with animated symbols
 					if config.plugins.MyMetrixLiteOther.showExtendedinfo.getValue() is False: # Weather enabled with animated symbols and extended info disabled
 						if config.plugins.MetrixWeather.weekday.getValue() is False: # Weather enabled with animated symbols and extended info disabled and weekday disabled
 							infobarSkinSearchAndReplace.append(['<panel name="INFOBARWEATHERWIDGET+1" />', '<panel name="INFOBARWEATHERWIDGET+%s-2" />' % config.plugins.MetrixWeather.forecast.value])
 						else: # Weather enabled with animated symbols and extended info disabled and weekday enabled
 							infobarSkinSearchAndReplace.append(['<panel name="INFOBARWEATHERWIDGET+1" />', '<panel name="INFOBARWEATHERWIDGET+%s-2_weekday" />' % config.plugins.MetrixWeather.forecast.value])
 					else: # Weather enabled with animated symbols and extended info enabled
-						if config.plugins.MyMetrixLiteOther.ExtendedinfoStyle.getValue() == "2": # Weather enabled with animated symbols and extended info enabled between clock and weather enclosed
+						if config.plugins.MyMetrixLiteOther.ExtendedinfoStyle.getValue() == "2" or config.plugins.MyMetrixLiteOther.ExtendedinfoStyle.getValue() == "3": # Weather enabled with animated symbols and extended info enabled between clock and weather enclosed or centered
 							if config.plugins.MetrixWeather.weekday.getValue() is False: # Weather enabled with animated symbols and extended info enabled between clock and weather enclosed and weekday disabled
 								if config.plugins.MetrixWeather.forecast.getValue() > 0: # Weather enabled with animated symbols and extended info enabled between clock and weather enclosed and weekday disabled and forecast greater than one days
-									infobarSkinSearchAndReplace.append(['<panel name="INFOBARWEATHERWIDGET+1" />', '<panel name="INFOBARWEATHERWIDGET+1" />'])
+									infobarSkinSearchAndReplace.append(['<panel name="INFOBARWEATHERWIDGET+1" />', '<panel name="INFOBARWEATHERWIDGET+1-2" />'])
 								else: # Weather enabled with animated symbols and extended info enabled between clock and weather enclosed and weekday disabled and forecast for zero days
 									infobarSkinSearchAndReplace.append(['<panel name="INFOBARWEATHERWIDGET+1" />', '<panel name="INFOBARWEATHERWIDGET+%s-2" />' % config.plugins.MetrixWeather.forecast.value])
 							else: # Weather enabled with animated symbols and extended info enabled between clock and weather enclosed and weekday enabled
 								if config.plugins.MetrixWeather.forecast.getValue() > 0: # Weather enabled with animated symbols and extended info enabled between clock and weather enclosed and weekday enabled and forecast greater than one days
-									infobarSkinSearchAndReplace.append(['<panel name="INFOBARWEATHERWIDGET+1" />', '<panel name="INFOBARWEATHERWIDGET+1_weekday" />'])
+									infobarSkinSearchAndReplace.append(['<panel name="INFOBARWEATHERWIDGET+1" />', '<panel name="INFOBARWEATHERWIDGET+1-2_weekday" />'])
 								else: # Weather enabled with animated symbols and extended info enabled between clock and weather enclosed and weekday enabled and forecast for zero days
 									infobarSkinSearchAndReplace.append(['<panel name="INFOBARWEATHERWIDGET+1" />', '<panel name="INFOBARWEATHERWIDGET+%s-2_weekday" />' % config.plugins.MetrixWeather.forecast.value])
 						else: # Weather enabled with animated symbols and extended info disabled
@@ -1193,7 +1193,7 @@ class ActivateSkinSettings:
 
 			type = config.plugins.MyMetrixLiteFonts.globalweatherweek_type.value
 			scale = config.plugins.MyMetrixLiteFonts.globalweatherweek_scale.value
-			old = '<font filename="/usr/share/enigma2/MetrixHD/fonts/OpenSans-Bold.ttf" name="global_weather_bold" scale="100" />'
+			old = '<font filename="/usr/share/enigma2/MetrixHD/fonts/DroidSans-Bold.ttf" name="global_weather_bold" scale="100" />'
 			new = '<font filename="' + type + '" name="global_weather_bold" scale="' + str(scale) + '" />'
 			if path.exists(type):
 				skinSearchAndReplace.append([old, new])


### PR DESCRIPTION
[Weather] Show only up to one day if service extended info is centered between weather and clock

[Weather] Set weekday font and translate setting to German

[Weather] Use animated symbols if animated symbols is set, extended service info is enclosed between weather and clock and more than one day forecast is set