### PR TITLE
YouTubeMain: add scale flag for thumbnail

### DIFF
--- a/usr/share/enigma2/MetrixHD/skinfiles/skin_plugins.xml
+++ b/usr/share/enigma2/MetrixHD/skinfiles/skin_plugins.xml
@@ -3474,8 +3474,8 @@
 		<widget source="list" render="Listbox" position="70,100" size="700,510" font="screen_text;20" itemHeight="72" scrollbarSliderBorderWidth="1" scrollbarWidth="10" scrollbarSliderForegroundColor="scrollbarSlidercolor" scrollbarSliderBorderColor="scrollbarSliderbordercolor" scrollbarMode="showOnDemand" backgroundColor="layer-a-background" foregroundColor="layer-a-foreground" backgroundColorSelected="layer-a-selection-background" foregroundColorSelected="layer-a-selection-foreground" transparent="1" >
 			<convert type="TemplatedMultiContent" >
 				{"template": [
-					MultiContentEntryPixmapAlphaTest(pos=(0,0), size=(100,72), png=2), # Thumbnail
-					MultiContentEntryText(pos=(110,8), size=(575,52), font=0, flags=RT_HALIGN_LEFT|RT_VALIGN_CENTER|RT_WRAP, text=3), # Title
+					MultiContentEntryPixmapAlphaBlend(pos=(0,0), size=(100,72), flags=BT_SCALE, png=2), # Thumbnail
+					MultiContentEntryText(pos=(110,8), size=(575,52), font=0, flags=RT_HALIGN_LEFT|RT_VALIGN_CENTER, text=3), # Title
 					MultiContentEntryText(pos=(120, 50), size=(200,22), font=1, flags=RT_HALIGN_LEFT, text=4), # Views
 					MultiContentEntryText(pos=(360,50), size=(200,22), 	font=1, flags=RT_HALIGN_LEFT, text=5), # Duration
 							],


### PR DESCRIPTION
Remove wrap flag in title.
Also use MultiContentEntryPixmapAlphaBlend for thumbnails.

Scale in thumbnail allows to use the LoadPixmap instead of picload.
Looks like dreambox is having trouble using OpenMP in picload to run things in parallel https://github.com/Taapat/enigma2-plugin-youtube/issues/152