### PR TITLE
[SecondInfobar] Fix alignment of event title

### DIFF
--- a/usr/share/enigma2/MetrixHD/skinfiles/skin_templates.xml
+++ b/usr/share/enigma2/MetrixHD/skinfiles/skin_templates.xml
@@ -2253,7 +2253,7 @@
 <!-- cf#_#rename -->
 		<screen name="INFOBAREPGWIDGET">
 			<!--/* EPGWidget -->
-			<widget backgroundColor="layer-a-background" foregroundColor="layer-a-accent1" font="epg_event;26" halign="right" noWrap="1" position="70,480" render="Label" size="555,35" source="session.Event_Now" transparent="1" valign="bottom" zPosition="2">
+			<widget backgroundColor="layer-a-background" foregroundColor="layer-a-accent1" font="epg_event;26" halign="left" noWrap="1" position="70,480" render="Label" size="555,35" source="session.Event_Now" transparent="1" valign="bottom" zPosition="2">
 				<convert type="EventName">Name</convert>
 			</widget>
 			<widget backgroundColor="layer-b-background" foregroundColor="layer-b-accent1" font="epg_event;26" halign="left" noWrap="1" position="655,458" render="Label" size="555,35" source="session.Event_Next" transparent="1" valign="bottom" zPosition="2">
@@ -2266,7 +2266,7 @@
 <!-- cf#_#rename -->
 		<screen name="INFOBAREPGWIDGET#_FHDscreen">
 			<!--/* EPGWidget FHD -->
-			<widget backgroundColor="layer-a-background" foregroundColor="layer-a-accent1" font="epg_event;40" halign="right" noWrap="1" position="105,720" render="Label" size="832,53" source="session.Event_Now" transparent="1" valign="bottom" zPosition="2">
+			<widget backgroundColor="layer-a-background" foregroundColor="layer-a-accent1" font="epg_event;40" halign="left" noWrap="1" position="105,720" render="Label" size="832,53" source="session.Event_Now" transparent="1" valign="bottom" zPosition="2">
 				<convert type="EventName">Name</convert>
 			</widget>
 			<widget backgroundColor="layer-b-background" foregroundColor="layer-b-accent1" font="epg_event;40" halign="left" noWrap="1" position="982,687" render="Label" size="832,53" source="session.Event_Next" transparent="1" valign="bottom" zPosition="2">
@@ -2279,7 +2279,7 @@
 <!-- cf#_#rename -->
 		<screen name="INFOBAREPGWIDGET#_UHDscreen">
 			<!--/* EPGWidget -->
-			<widget backgroundColor="layer-a-background" foregroundColor="layer-a-accent1" font="epg_event;78" halign="right" noWrap="1" position="210,1440" render="Label" size="1665,105" source="session.Event_Now" transparent="1" valign="bottom" zPosition="2">
+			<widget backgroundColor="layer-a-background" foregroundColor="layer-a-accent1" font="epg_event;78" halign="left" noWrap="1" position="210,1440" render="Label" size="1665,105" source="session.Event_Now" transparent="1" valign="bottom" zPosition="2">
 				<convert type="EventName">Name</convert>
 			</widget>
 			<widget backgroundColor="layer-b-background" foregroundColor="layer-b-accent1" font="epg_event;78" halign="left" noWrap="1" position="1965,1374" render="Label" size="1665,105" source="session.Event_Next" transparent="1" valign="bottom" zPosition="2">


### PR DESCRIPTION
This follows the changes made in commit https://github.com/openatv/MetrixHD/commit/84956fa6e50fae0f3427cfbc9f9e9901430f242d