### PR TITLE
[MetrixWeather] Use string as default value for icontype

### DIFF
--- a/usr/lib/enigma2/python/Plugins/Extensions/MyMetrixLite/plugin.py
+++ b/usr/lib/enigma2/python/Plugins/Extensions/MyMetrixLite/plugin.py
@@ -43,7 +43,7 @@ config.plugins.MetrixWeather = ConfigSubsection()
 config.plugins.MetrixWeather.enabled = ConfigYesNo(default=True)
 config.plugins.MetrixWeather.detail = ConfigYesNo(default=False)
 config.plugins.MetrixWeather.type = ConfigYesNo(default=False)
-config.plugins.MetrixWeather.icontype = ConfigSelection(default=0, choices=[("0", _("Meteo Icons")), ("1", _("Animated Icons")), ("2", _("Static Icons"))])
+config.plugins.MetrixWeather.icontype = ConfigSelection(default="0", choices=[("0", _("Meteo Icons")), ("1", _("Animated Icons")), ("2", _("Static Icons"))])
 if config.plugins.MetrixWeather.type.value:  # Restore old setting
 	config.plugins.MetrixWeather.icontype.value = "1"
 	config.plugins.MetrixWeather.icontype.save()


### PR DESCRIPTION
This fixes the icon type shown per default after clean flash.