### PR TITLE
[MyMetrixLite] Weather: 'icon night switch" can now be deactivated

### DIFF
--- a/usr/lib/enigma2/python/Plugins/Extensions/MyMetrixLite/plugin.py
+++ b/usr/lib/enigma2/python/Plugins/Extensions/MyMetrixLite/plugin.py
@@ -51,6 +51,7 @@ if config.plugins.MetrixWeather.type.value:  # Restore old setting
 	config.plugins.MetrixWeather.type.save()
 config.plugins.MetrixWeather.animationspeed = ConfigSelection(default="100", choices=[("0", _("Off")), ("20", _("+ 4")), ("40", _("+ 3")), ("60", _("+ 2")), ("80", _("+ 1")), ("100", _("Default")), ("125", _("- 1")), ("150", _("- 2")), ("200", _("- 3")), ("300", _("- 4"))])
 config.plugins.MetrixWeather.iconpath = ConfigText(default="")
+config.plugins.MetrixWeather.nighticons = ConfigYesNo(default=True)
 config.plugins.MetrixWeather.cachedata = ConfigSelection(default="60", choices=[("0", _("Disabled"))] + [(str(x), _("%d Minutes") % x) for x in (30, 60, 120)])
 config.plugins.MetrixWeather.MoviePlayer = ConfigYesNo(default=True)
 config.plugins.MetrixWeather.refreshInterval = ConfigSelectionNumber(0, 1440, 30, default=120, wraparound=True)
@@ -249,7 +250,7 @@ class InfoBarMetrixWeather(Screen):
 			self["IconCode"].setText("")
 		else:
 			iconcode = data["current"]["yahooCode"]
-			if isnight and iconcode in nightswitch:
+			if config.plugins.MetrixWeather.nighticons.value and isnight and iconcode in nightswitch:
 				iconcode = nightswitch[iconcode]
 			self["IconCode"].setText(iconcode)
 			self["FontCode"].setText("")

--- a/usr/lib/enigma2/python/Plugins/Extensions/MyMetrixLite/setup.xml
+++ b/usr/lib/enigma2/python/Plugins/Extensions/MyMetrixLite/setup.xml
@@ -10,6 +10,7 @@
 			<item level="0" text="MetrixWeather icon style" description="Select the style of MetrixWeather icons to be used.">config.plugins.MetrixWeather.icontype</item>
 			<item level="0" text="MetrixWeather icon path" description="Select the path to where the MetrixWeather icons can be found. This path cannot be empty!" conditional="config.plugins.MetrixWeather.icontype.value == '2'">config.plugins.MetrixWeather.iconpath</item>
 			<item level="0" text="MetrixWeather animations speed" description="Select the animations speed for the animated icons." conditional="config.plugins.MetrixWeather.icontype.value == '1'">config.plugins.MetrixWeather.animationspeed</item>
+			<item level="0" text="MetrixWeather icon night switch" description="Choose whether the 'night switch' should be activated or not. Some icons are then displayed as night icons with moon.">config.plugins.MetrixWeather.nighticons</item>
 			<item level="0" text="Refresh interval" description="Specify how often MetrixWeather retrieves its data from the server. 'Once' means the data will loaded only once after a GUI or system start.">config.plugins.MetrixWeather.refreshInterval</item>
 			<item level="0" text="Show forecast" description="Select the number of days of weather forecast to be displayed.">config.plugins.MetrixWeather.forecast</item>
 			<item level="0" text="Show detail" description="Enable this option to display the wind speed, direction, 'feels like' temperature and humidity.">config.plugins.MetrixWeather.detail</item>


### PR DESCRIPTION
- remapping of some weather icons to night mode can now be switched on/off