### PR TITLE
[AutoBoquetsMaker Menu] Add buttons

### DIFF
--- a/usr/share/enigma2/MetrixHD/skinfiles/skin_plugins.xml
+++ b/usr/share/enigma2/MetrixHD/skinfiles/skin_plugins.xml
@@ -317,6 +317,7 @@
 				}
 			</convert>
 		</widget>
+		<panel name="ScreenTemplateAllColorButtons_template1" />
 		<panel name="template1_2layer" />
 		<panel name="_me-buttons_template1" />
 		<ePixmap position="890,175" size="256,256" zPosition="2" pixmap="icons/menu_scan_autobouquetsmakermaker.png" transparent="1" alphatest="blend" />


### PR DESCRIPTION
Add buttons to ABM menu

```
06:55:48.9648 [Skin] Processing screen 'AutoBouquetsMaker_Menu', position=(0, 0), size=(1280x720) for module 'AutoBouquetsMaker_Menu'.
06:55:48.9721 [Screen] Warning: Skin is missing element 'key_red' in <class 'Plugins.SystemPlugins.AutoBouquetsMaker.menu.AutoBouquetsMaker_Menu'>.
06:55:48.9723 [Screen] Warning: Skin is missing element 'key_green' in <class 'Plugins.SystemPlugins.AutoBouquetsMaker.menu.AutoBouquetsMaker_Menu'>.
```