### PR TITLE
Update de.po

### DIFF
--- a/locale/de.po
+++ b/locale/de.po
@@ -1743,7 +1743,7 @@ msgid "height"
 msgstr "Höhe"
 
 msgid "helptext"
-msgstr "Hilfstext"
+msgstr "Auswählen, dann OK drücken."
 
 msgid "in Image included Fonts"
 msgstr "Im Image enthaltene Schriftarten"


### PR DESCRIPTION
"helptext" - German "Hilfstext" - apears only if you press OK to see the multiple options.  
But there "helptext" IS the helptext, what does not mean anything.  
"Auswählen, dann OK drücken." means "Choose option, than press OK." and IS the helptext.  
 I hope, I'm right... ;)