### PR TITLE
MetrixHD: show TEXT button in MultiBootManager footer

### DIFF
--- a/usr/share/enigma2/MetrixHD/skinfiles/skin_openatv.xml
+++ b/usr/share/enigma2/MetrixHD/skinfiles/skin_openatv.xml
@@ -3962,7 +3962,7 @@ if len(listitems.list) &gt; 2:
 		<panel name="T_Desc_810" />
 		<panel name="ScreenTemplateAllColorButtons_template1" />
 		<panel name="template1_2layer" />
-		<panel name="_oe-buttons_template1" />
+		<panel name="toe-buttons_template1" />
 	</screen>
 	<screen name="KexecInit" position="0,0" size="1280,720" title="Kexec MultiBoot Manager" flags="wfNoBorder" backgroundColor="transparent">
 		<panel name="T_Title" />


### PR DESCRIPTION
Switch the MultiBootManager screen's button-bar panel from _oe-buttons_template1 (OK + EXIT) to toe-buttons_template1 (TEXT + OK + EXIT) so the new TXT/Rename binding in enigma2's MultiBoot manager has a visible button affordance.