### PR TITLE
NetworkWiFiScan: room for the WPA3 and enterprise labels

### DIFF
--- a/usr/share/enigma2/MetrixHD/skinfiles/skin_openatv.xml
+++ b/usr/share/enigma2/MetrixHD/skinfiles/skin_openatv.xml
@@ -129,15 +129,15 @@
 		<panel name="T_Title" />
 		<widget source="list" render="Listbox" position="70,100" size="700,480" scrollbarMode="showOnDemandShift">
 			<template name="Default" fonts="Regular;22,Regular;20,enigma2icons;20" itemHeight="60">
-				<panel position="0,0" size="e,30" layout="horizontal">
+				<panel position="0,0" size="e-15,30" layout="horizontal">
 					<text index="Name" position="left" size="460,30" font="0" horizontalAlignment="left" padding="5,0" verticalAlignment="center" />
 					<text index="Channel" position="right" size="110,30" font="1" horizontalAlignment="right" padding="5,0" verticalAlignment="center" />
 				</panel>
-				<panel position="20,30" size="e-20,30" layout="horizontal">
+				<panel position="20,30" size="e-35,30" layout="horizontal">
 					<text index="Glyph" position="left" size="30,e" font="2" horizontalAlignment="center" padding="5,0" verticalAlignment="center" />
 					<text index="Percentage" position="left" size="70,e" font="1" horizontalAlignment="right" padding="5,0" verticalAlignment="center" />
 					<text index="dBm" position="left" size="100,e" font="1" horizontalAlignment="right" padding="5,0" verticalAlignment="center" />
-					<text index="Encryption" position="left" size="110,e" font="1" horizontalAlignment="center" padding="5,0" verticalAlignment="center" />
+					<text index="Encryption" position="left" size="240,e" font="1" horizontalAlignment="left" padding="15,0" verticalAlignment="center" />
 					<text index="Frequency" position="right" size="150,e" font="1" horizontalAlignment="right" padding="5,0" verticalAlignment="center" />
 				</panel>
 			</template>


### PR DESCRIPTION

The encryption column holds 110 pixels, which fits `WPA2` and nothing else. Once
the scan tells WPA3 and enterprise networks apart, the labels reach
`WPA2/WPA3 Enterprise` and are cut off.

The row can spare the width. The columns left of the label end after 325 pixels and
the frequency is anchored on the right, so the space in between was unused anyway —
the column grows to 240 pixels without displacing anything.

Centred, it also sat oddly between two right aligned neighbours, and an overlong
value lost its beginning rather than its end. Left aligned with 15 pixels of padding
every label starts on the same edge and keeps its distance to the dBm column.

Both panels lose the width of the scroll bar, which used to overlap them and clipped
the frequency to `2.437 GH`.

| | before | after |
|---|---|---|
| panel, first row | `e,30` | `e-15,30` |
| panel, second row | `e-20,30` | `e-35,30` |
| encryption | `110,e`, centred, `padding="5,0"` | `240,e`, left, `padding="15,0"` |

<img width="1280" height="720" alt="shot1" src="https://github.com/user-attachments/assets/67eb8891-80e1-445e-8147-25967568dbdd" />

### Companion change

The longer labels come from openatv/enigma2#3889, which
tells WPA3 and enterprise networks apart in the scan. The two are independent —
neither breaks without the other, they only look right together.
